### PR TITLE
Advanced image metadata

### DIFF
--- a/cargo-wharf-frontend/src/config/base.rs
+++ b/cargo-wharf-frontend/src/config/base.rs
@@ -6,6 +6,7 @@ use failure::{bail, format_err, Error};
 use log::*;
 use serde::{Deserialize, Serialize};
 
+use buildkit_frontend::oci::{ExposedPort, Signal};
 use buildkit_llb::ops::source::ImageSource;
 use buildkit_llb::prelude::*;
 
@@ -35,6 +36,10 @@ pub struct OutputConfig {
     pub entrypoint: Option<Vec<String>>,
     pub args: Option<Vec<String>>,
     pub env: Option<BTreeMap<String, String>>,
+    pub expose: Option<Vec<ExposedPort>>,
+    pub volumes: Option<Vec<PathBuf>>,
+    pub labels: Option<BTreeMap<String, String>>,
+    pub stop_signal: Option<Signal>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -127,6 +132,10 @@ fn transformation() {
                         entrypoint: None,
                         args: None,
                         env: None,
+                        expose: None,
+                        volumes: None,
+                        labels: None,
+                        stop_signal: None,
                     }),
 
                     builder: None,
@@ -194,6 +203,10 @@ fn transformation() {
                 entrypoint: None,
                 args: None,
                 env: None,
+                expose: None,
+                volumes: None,
+                labels: None,
+                stop_signal: None,
             },
             binaries: vec![
                 BinaryDefinition {
@@ -230,6 +243,10 @@ fn duplicated_config() {
                         entrypoint: None,
                         args: None,
                         env: None,
+                        expose: None,
+                        volumes: None,
+                        labels: None,
+                        stop_signal: None,
                     }),
 
                     binary: None,
@@ -272,6 +289,10 @@ fn duplicated_config() {
                         entrypoint: None,
                         args: None,
                         env: None,
+                        expose: None,
+                        volumes: None,
+                        labels: None,
+                        stop_signal: None,
                     }),
 
                     binary: None,
@@ -288,6 +309,10 @@ fn duplicated_config() {
                         entrypoint: None,
                         args: None,
                         env: None,
+                        expose: None,
+                        volumes: None,
+                        labels: None,
+                        stop_signal: None,
                     }),
 
                     builder: None,
@@ -338,6 +363,10 @@ fn missing_config() {
                     entrypoint: None,
                     args: None,
                     env: None,
+                    expose: None,
+                    volumes: None,
+                    labels: None,
+                    stop_signal: None,
                 }),
 
                 builder: None,

--- a/cargo-wharf-frontend/src/config/output.rs
+++ b/cargo-wharf-frontend/src/config/output.rs
@@ -5,6 +5,7 @@ use failure::{format_err, Error, ResultExt};
 use log::*;
 use serde::Serialize;
 
+use buildkit_frontend::oci::{ExposedPort, Signal};
 use buildkit_frontend::Bridge;
 use buildkit_llb::ops::source::ImageSource;
 use buildkit_llb::prelude::*;
@@ -23,6 +24,12 @@ pub struct OutputImage {
     pub workdir: Option<PathBuf>,
     pub entrypoint: Option<Vec<String>>,
     pub cmd: Option<Vec<String>>,
+
+    #[serde(rename = "expose")]
+    pub exposed_ports: Option<Vec<ExposedPort>>,
+    pub volumes: Option<Vec<PathBuf>>,
+    pub labels: Option<BTreeMap<String, String>>,
+    pub stop_signal: Option<Signal>,
 }
 
 impl OutputImage {
@@ -73,6 +80,11 @@ impl OutputImage {
             user: config.user.or(spec.user),
             workdir: config.workdir.or(spec.working_dir),
 
+            exposed_ports: config.expose,
+            volumes: config.volumes,
+            labels: config.labels,
+            stop_signal: config.stop_signal,
+
             env,
             entrypoint,
             cmd,
@@ -87,6 +99,10 @@ impl OutputImage {
             entrypoint: config.entrypoint,
             cmd: config.args,
             workdir: config.workdir,
+            exposed_ports: config.expose,
+            volumes: config.volumes,
+            labels: config.labels,
+            stop_signal: config.stop_signal,
         }
     }
 

--- a/cargo-wharf-frontend/src/query.rs
+++ b/cargo-wharf-frontend/src/query.rs
@@ -79,10 +79,10 @@ impl<'a> GraphQuery<'a> {
                 user: output.user.clone(),
                 working_dir: output.workdir.clone(),
 
-                labels: None,
-                volumes: None,
-                exposed_ports: None,
-                stop_signal: None,
+                labels: self.config.output_image().labels.clone(),
+                volumes: self.config.output_image().volumes.clone(),
+                exposed_ports: self.config.output_image().exposed_ports.clone(),
+                stop_signal: self.config.output_image().stop_signal,
             },
 
             Profile::ReleaseTests | Profile::DebugTests => ImageConfig {

--- a/examples/single-bin/Cargo.toml
+++ b/examples/single-bin/Cargo.toml
@@ -22,9 +22,16 @@ image = "scratch"
 workdir = "/"
 entrypoint = ["/bin/wharf-output"]
 args = ["predefined arg"]
+expose = ["3500/tcp", "3600/udp", "3700"]
+volumes = ["/local", "/data"]
+stop_signal = "SIGINT"
 
 [package.metadata.wharf.output.env]
 "NAME 1" = "VALUE 1"
+
+[package.metadata.wharf.output.labels]
+"simple-label" = "simple value"
+"my.awesome.label" = "another value"
 
 [[package.metadata.wharf.binary]]
 name = "single-bin"

--- a/tests/integration/metadata.bats
+++ b/tests/integration/metadata.bats
@@ -1,0 +1,27 @@
+load common
+
+function setup() {
+    maybe_build_container_tools_image
+    maybe_build_frontend_image
+}
+
+@test "labels" {
+    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+
+    run docker image inspect cargo-wharf/example-single-bin -f "{{.Config.Labels}}"
+    [[ "$output" == "map[my.awesome.label:another value simple-label:simple value]" ]]
+}
+
+@test "volumes" {
+    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+
+    run docker image inspect cargo-wharf/example-single-bin -f "{{.Config.Volumes}}"
+    [[ "$output" == "map[/data:{} /local:{}]" ]]
+}
+
+@test "exposed ports" {
+    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+
+    run docker image inspect cargo-wharf/example-single-bin -f "{{.Config.ExposedPorts}}"
+    [[ "$output" == "map[3500/tcp:{} 3600/udp:{} 3700/tcp:{}]" ]]
+}


### PR DESCRIPTION
Trivial change to parse the advanced metadata (`VOLUME`, `EXPOSE`, `LABEL`) values from the config and pass it to BuildKit.

fixes #17 