### PR TITLE
Use docker-buildx for integration testing

### DIFF
--- a/.ci/install-buildx.sh
+++ b/.ci/install-buildx.sh
@@ -4,4 +4,4 @@ mkdir -p ~/.docker/cli-plugins
 curl -L https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
 chmod a+x ~/.docker/cli-plugins/docker-buildx
 
-docker buildx create --name ci-builder --use
+docker buildx create --driver-opt network=host --name ci-builder --use

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "buildkit-llb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "buildkit-llb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "buildkit-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -141,15 +141,17 @@ dependencies = [
 
 [[package]]
 name = "buildkit-llb"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "buildkit-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -282,8 +284,9 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "async-trait 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "buildkit-frontend 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "buildkit-llb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "buildkit-llb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "buildkit-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2379,7 +2382,7 @@ dependencies = [
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum buildkit-frontend 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d37c95b478f2e6735453d5278684cdd536146bea26b96fce6360e754db94ec45"
-"checksum buildkit-llb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a20825fd41baa759b7dd0cf9c81e9d062ded62e30d73d299d1520f788fde5756"
+"checksum buildkit-llb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffbc4ba4b7940de6cf055eedf0d9fff2f45b938eb8e62d5bbf2db08325b41bf"
 "checksum buildkit-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90d32365016a8e3a4f5c3130509fbe79d10ec9b5756d85004f1f48bc63d38fed"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"

--- a/cargo-wharf-frontend/Cargo.toml
+++ b/cargo-wharf-frontend/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 take_mut = "0.2"
 
 [build-dependencies]
+cfg-if = "0.1"
 semver = { version = "0.9", features = ["serde"] }
 serde = "1.0"
 toml = "0.5"
@@ -39,6 +40,7 @@ maplit = "1.0"
 pretty_assertions = "0.6"
 
 [features]
+integration-testing = []
 local-container-tools = []
 
 [package.metadata.wharf.builder]

--- a/cargo-wharf-frontend/build.rs
+++ b/cargo-wharf-frontend/build.rs
@@ -3,23 +3,32 @@ use serde::Deserialize;
 
 fn main() {
     println!(
-        "cargo:rustc-env=CONTAINER_TOOLS_VERSION={}",
-        get_container_tools_version()
+        "cargo:rustc-env=CONTAINER_TOOLS_REF={}",
+        get_container_tools_ref()
     );
 }
 
-#[cfg(feature = "local-container-tools")]
-fn get_container_tools_version() -> &'static str {
-    "local"
-}
+cfg_if::cfg_if! {
+    if #[cfg(feature = "integration-testing")] {
+        fn get_container_tools_ref() -> &'static str {
+            "localhost:10395/denzp/cargo-container-tools:local"
+        }
+    } else if #[cfg(feature = "local-container-tools")] {
+        fn get_container_tools_ref() -> &'static str {
+            "denzp/cargo-container-tools:local"
+        }
+    } else {
+        fn get_container_tools_ref() -> String {
+            let container_tools_manifest: Manifest =
+                toml::from_str(include_str!("../cargo-container-tools/Cargo.toml"))
+                    .expect("Unable to parse container-tools crate manifest");
 
-#[cfg(not(feature = "local-container-tools"))]
-fn get_container_tools_version() -> String {
-    let container_tools_manifest: Manifest =
-        toml::from_str(include_str!("../cargo-container-tools/Cargo.toml"))
-            .expect("Unable to parse container-tools crate manifest");
-
-    format!("v{}", container_tools_manifest.package.version)
+            format!(
+                "denzp/cargo-container-tools:v{}",
+                container_tools_manifest.package.version
+            )
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/cargo-wharf-frontend/src/shared.rs
+++ b/cargo-wharf-frontend/src/shared.rs
@@ -24,10 +24,7 @@ pub mod tools {
     use super::*;
 
     lazy_static! {
-        pub static ref IMAGE: ImageSource = Source::image(format!(
-            "denzp/cargo-container-tools:{}",
-            env!("CONTAINER_TOOLS_VERSION")
-        ));
+        pub static ref IMAGE: ImageSource = Source::image(env!("CONTAINER_TOOLS_REF"));
     }
 
     pub const METADATA_COLLECTOR: &str = "/usr/local/bin/cargo-metadata-collector";

--- a/examples/multi-bin/Cargo.toml
+++ b/examples/multi-bin/Cargo.toml
@@ -1,4 +1,4 @@
-# syntax = denzp/cargo-wharf-frontend:local
+# syntax = localhost:10395/denzp/cargo-wharf-frontend:local
 
 [package]
 name = "multi-bin"
@@ -15,11 +15,11 @@ openssl-sys = "0.9"
 [package.metadata.wharf.builder]
 image = "clux/muslrust:nightly-2019-09-28"
 target = "x86_64-unknown-linux-musl"
-# setup-commands = [
-#   { command = ["apt-get", "update"], display = "Update apt-get cache" },
-#   { command = ["apt-get", "install", "-y", "protobuf-compiler"] },
-#   { shell = "echo '' > /custom-output" },
-# ]
+setup-commands = [
+  { command = ["apt-get", "update"], display = "Update apt-get cache" },
+  { command = ["apt-get", "install", "-y", "protobuf-compiler"] },
+  { shell = "echo '' > /custom-output" },
+]
 
 [package.metadata.wharf.output]
 image = "scratch"

--- a/examples/multi-bin/build.rs
+++ b/examples/multi-bin/build.rs
@@ -3,9 +3,9 @@ use std::fs::metadata;
 fn main() {
     // Check if build dependencies were installed. Used for the integration testing.
 
-    // metadata("/usr/bin/protoc")
-    //     .expect("Unable to find `/usr/bin/protoc`. Custom builder setup failed!");
+    metadata("/usr/bin/protoc")
+        .expect("Unable to find `/usr/bin/protoc`. Custom builder setup failed!");
 
-    // metadata("/custom-output")
-    //     .expect("Unable to find `/tmp/custom-output`. Custom builder setup failed!");
+    metadata("/custom-output")
+        .expect("Unable to find `/tmp/custom-output`. Custom builder setup failed!");
 }

--- a/examples/single-bin/Cargo.toml
+++ b/examples/single-bin/Cargo.toml
@@ -1,4 +1,4 @@
-# syntax = denzp/cargo-wharf-frontend:local
+# syntax = localhost:10395/denzp/cargo-wharf-frontend:local
 
 [package]
 name = "single-bin"

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -1,4 +1,4 @@
-# syntax = denzp/cargo-wharf-frontend:local
+# syntax = localhost:10395/denzp/cargo-wharf-frontend:local
 
 [workspace]
 members = [

--- a/tests/integration/debug.bats
+++ b/tests/integration/debug.bats
@@ -1,15 +1,21 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
+}
+
+function teardown() {
+    remove_registry
 }
 
 @test "debug output" {
     rm -f $BATS_TMPDIR/*.json
     rm -f $BATS_TMPDIR/*.pb
 
-    docker build -f examples/single-bin/Cargo.toml examples/single-bin \
+    docker buildx build -f examples/single-bin/Cargo.toml examples/single-bin \
         -o type=local,dest=$BATS_TMPDIR \
         --build-arg debug=all
 
@@ -23,7 +29,7 @@ function setup() {
     rm -f $BATS_TMPDIR/*.json
     rm -f $BATS_TMPDIR/*.pb
 
-    docker build -f examples/single-bin/Cargo.toml examples/single-bin \
+    docker buildx build -f examples/single-bin/Cargo.toml examples/single-bin \
         -o type=local,dest=$BATS_TMPDIR \
         --build-arg debug=build-plan,build-graph
 

--- a/tests/integration/example-multi-bin.bats
+++ b/tests/integration/example-multi-bin.bats
@@ -1,12 +1,21 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
 }
 
+function teardown() {
+    remove_registry
+
+    docker rmi -f cargo-wharf/example-multi-bin:test || true
+    docker rmi -f cargo-wharf/example-multi-bin || true
+}
+
 @test "multi-bin :: binaries" {
-    docker build -f examples/multi-bin/Cargo.toml -t cargo-wharf/example-multi-bin examples/multi-bin
+    docker buildx build --load -f examples/multi-bin/Cargo.toml -t cargo-wharf/example-multi-bin examples/multi-bin
 
     run docker run --rm cargo-wharf/example-multi-bin /bin/bin-1
     [ "$status" -eq 0 ]
@@ -18,7 +27,7 @@ function setup() {
 }
 
 @test "multi-bin :: tests" {
-    docker build -f examples/multi-bin/Cargo.toml -t cargo-wharf/example-multi-bin:test examples/multi-bin --build-arg profile=test
+    docker buildx build --load -f examples/multi-bin/Cargo.toml -t cargo-wharf/example-multi-bin:test examples/multi-bin --build-arg profile=test
 
     run docker run --rm cargo-wharf/example-multi-bin:test
     [ "$status" -eq 0 ]

--- a/tests/integration/example-single-bin.bats
+++ b/tests/integration/example-single-bin.bats
@@ -1,12 +1,21 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
 }
 
+function teardown() {
+    remove_registry
+
+    docker rmi -f cargo-wharf/example-single-bin:test || true
+    docker rmi -f cargo-wharf/example-single-bin || true
+}
+
 @test "single-bin :: binaries" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
 
     run docker run --rm cargo-wharf/example-single-bin
     [ "$status" -eq 0 ]
@@ -20,7 +29,7 @@ function setup() {
 }
 
 @test "single-bin :: tests" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin:test examples/single-bin --build-arg profile=test
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin:test examples/single-bin --build-arg profile=test
 
     run docker run --rm cargo-wharf/example-single-bin:test
     [ "$status" -eq 0 ]

--- a/tests/integration/example-workspace.bats
+++ b/tests/integration/example-workspace.bats
@@ -1,12 +1,21 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
 }
 
+function teardown() {
+    remove_registry
+
+    docker rmi -f cargo-wharf/example-workspace:test || true
+    docker rmi -f cargo-wharf/example-workspace || true
+}
+
 @test "workspace example :: binaries" {
-    docker build -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace examples/workspace
+    docker buildx build --load -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace examples/workspace
 
     run docker run --rm cargo-wharf/example-workspace
     [ "$status" -eq 0 ]
@@ -24,7 +33,7 @@ function setup() {
 }
 
 @test "workspace example :: custom commands" {
-    docker build -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace examples/workspace
+    docker buildx build --load -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace examples/workspace
 
     run docker run --rm cargo-wharf/example-workspace cat /custom-setup
     [ "$status" -eq 0 ]
@@ -36,7 +45,7 @@ function setup() {
 }
 
 @test "workspace example :: tests" {
-    docker build -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace:test examples/workspace --build-arg profile=test
+    docker buildx build --load -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace:test examples/workspace --build-arg profile=test
 
     run docker run --rm cargo-wharf/example-workspace:test
     [ "$status" -eq 1 ]

--- a/tests/integration/features.bats
+++ b/tests/integration/features.bats
@@ -1,12 +1,21 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
 }
 
+function teardown() {
+    remove_registry
+
+    docker rmi -f cargo-wharf/example-single-bin || true
+    docker rmi -f cargo-wharf/example-workspace || true
+}
+
 @test "default behavior" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
 
     run docker run --rm cargo-wharf/example-single-bin
     [[ "$output" == *"feature-1 is on"* ]]
@@ -14,7 +23,7 @@ function setup() {
 }
 
 @test "no-default-features" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin --build-arg no-default-features=true
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin --build-arg no-default-features=true
 
     run docker run --rm cargo-wharf/example-single-bin
     [[ "$output" != *"feature-1 is on"* ]]
@@ -22,7 +31,7 @@ function setup() {
 }
 
 @test "no-default-features + features" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin --build-arg no-default-features=true --build-arg features=feature-2
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin --build-arg no-default-features=true --build-arg features=feature-2
 
     run docker run --rm cargo-wharf/example-single-bin
     [[ "$output" != *"feature-1 is on"* ]]
@@ -30,7 +39,7 @@ function setup() {
 }
 
 @test "features" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin --build-arg features=feature-2
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin --build-arg features=feature-2
 
     run docker run --rm cargo-wharf/example-single-bin
     [[ "$output" == *"feature-1 is on"* ]]
@@ -38,7 +47,7 @@ function setup() {
 }
 
 @test "workspace features" {
-    docker build -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace examples/workspace --build-arg features=the-special-feature --build-arg manifest-path=binary-1/Cargo.toml
+    docker buildx build --load -f examples/workspace/Cargo.toml -t cargo-wharf/example-workspace examples/workspace --build-arg features=the-special-feature --build-arg manifest-path=binary-1/Cargo.toml
 
     run docker run --rm cargo-wharf/example-workspace binary-1
     [[ "$output" == *"the-special-feature is on"* ]]

--- a/tests/integration/helpers/registry.bash
+++ b/tests/integration/helpers/registry.bash
@@ -1,0 +1,8 @@
+function install_registry {
+    docker run -d -p 10395:5000 --restart=always --name cargo-wharf-integration-tests-registry registry:2
+    sleep 2
+}
+
+function remove_registry {
+    docker rm -f cargo-wharf-integration-tests-registry
+}

--- a/tests/integration/metadata.bats
+++ b/tests/integration/metadata.bats
@@ -1,26 +1,34 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
 }
 
+function teardown() {
+    remove_registry
+
+    docker rmi -f cargo-wharf/example-single-bin || true
+}
+
 @test "labels" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
 
     run docker image inspect cargo-wharf/example-single-bin -f "{{.Config.Labels}}"
     [[ "$output" == "map[my.awesome.label:another value simple-label:simple value]" ]]
 }
 
 @test "volumes" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
 
     run docker image inspect cargo-wharf/example-single-bin -f "{{.Config.Volumes}}"
     [[ "$output" == "map[/data:{} /local:{}]" ]]
 }
 
 @test "exposed ports" {
-    docker build -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
+    docker buildx build --load -f examples/single-bin/Cargo.toml -t cargo-wharf/example-single-bin examples/single-bin
 
     run docker image inspect cargo-wharf/example-single-bin -f "{{.Config.ExposedPorts}}"
     [[ "$output" == "map[3500/tcp:{} 3600/udp:{} 3700/tcp:{}]" ]]

--- a/tests/integration/pretty-output.bats
+++ b/tests/integration/pretty-output.bats
@@ -1,17 +1,25 @@
-load common
+load helpers/images
+load helpers/registry
 
 function setup() {
+    install_registry
     maybe_build_container_tools_image
     maybe_build_frontend_image
 }
 
+function teardown() {
+    remove_registry
+
+    docker rmi -f cargo-wharf/example-multi-bin || true
+}
+
 @test "pretty print binaries" {
-    run docker build -f examples/multi-bin/Cargo.toml examples/multi-bin
+    run docker buildx build --load -f examples/multi-bin/Cargo.toml -t cargo-wharf/example-multi-bin examples/multi-bin
 
     [ "$status" -eq 0 ]
-    # [[ "$output" == *"Running   \`Update apt-get cache\`"* ]]
-    # [[ "$output" == *"Running   \`apt-get install -y protobuf-compiler\`"* ]]
-    # [[ "$output" == *"Running   \`echo '' > /custom-output\`"* ]]
+    [[ "$output" == *"Running   \`Update apt-get cache\`"* ]]
+    [[ "$output" == *"Running   \`apt-get install -y protobuf-compiler\`"* ]]
+    [[ "$output" == *"Running   \`echo '' > /custom-output\`"* ]]
     [[ "$output" == *"Compiling pkg-config"* ]]
     [[ "$output" == *"Compiling cc"* ]]
     [[ "$output" == *"Compiling openssl-sys [build script]"* ]]
@@ -22,12 +30,12 @@ function setup() {
 }
 
 @test "pretty print tests" {
-    run docker build -f examples/multi-bin/Cargo.toml examples/multi-bin --build-arg profile=test
+    run docker buildx build --load -f examples/multi-bin/Cargo.toml -t cargo-wharf/example-multi-bin examples/multi-bin --build-arg profile=test
 
     [ "$status" -eq 0 ]
-    # [[ "$output" == *"Running   \`Update apt-get cache\`"* ]]
-    # [[ "$output" == *"Running   \`apt-get install -y protobuf-compiler\`"* ]]
-    # [[ "$output" == *"Running   \`echo '' > /custom-output\`"* ]]
+    [[ "$output" == *"Running   \`Update apt-get cache\`"* ]]
+    [[ "$output" == *"Running   \`apt-get install -y protobuf-compiler\`"* ]]
+    [[ "$output" == *"Running   \`echo '' > /custom-output\`"* ]]
     [[ "$output" == *"Compiling pkg-config"* ]]
     [[ "$output" == *"Compiling cc"* ]]
     [[ "$output" == *"Compiling openssl-sys [build script]"* ]]


### PR DESCRIPTION
This, hopefully, should allow enabling previously disabled custom commands tests.